### PR TITLE
 added heading and close button, and on:closed event

### DIFF
--- a/src/lib/components/Sheet.svelte
+++ b/src/lib/components/Sheet.svelte
@@ -60,7 +60,6 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 -->
 
 <script lang="ts">
-	import { onMount } from "svelte";
 	import {
 		blur,
 		fly,
@@ -98,12 +97,13 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
   /** if set to a value, the sheet will have a heading section with a close button */
  	export let title = '';
 
-	let sheet: HTMLDivElement;
-	const closeSheet = () => {
+	 let sheet: HTMLDivElement;
+	 const dispatch = createEventDispatcher();
+	
+	 const closeSheet = () => {
 		display = false;
 		dispatch('closed');
 	}
-
 
 	const onKeyDown = (e: KeyboardEvent) => {
 		if (e.key === "Escape") {

--- a/src/lib/components/Sheet.svelte
+++ b/src/lib/components/Sheet.svelte
@@ -15,13 +15,19 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 - `position` - determines the position of sheet
 - `transitionSheet` - flies the sheet, set to `false` to remove
 - `transition` - blurs the entire component, set to `false` to remove
-- `title` - title of the sheet
 
 @slots
 
 | name       | purpose                         | default value |
 | ---------- | ------------------------------- | ------------- |
 | `default`  | content                         | `Content`     |
+
+@events
+
+| name      | event              |
+| --------- | ------------------ |
+| `mount`   | sheet is mounted   | 
+| `destroy` | sheet is destroyed | 
 
 @example
 
@@ -60,16 +66,16 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 -->
 
 <script lang="ts">
+	import { createEventDispatcher, onMount } from "svelte";
 	import {
 		blur,
 		fly,
 		type BlurParams,
 		type FlyParams,
 	} from "svelte/transition";
-	import { createEventDispatcher, onMount } from 'svelte';
-  import { prefersReducedMotion } from "$lib/util/accessibility";
-	import { duration } from "$lib/util/transition";
 	import type { Action } from "svelte/action";
+	import { prefersReducedMotion } from "$lib/util/accessibility";
+	import { duration } from "$lib/util/transition";
 
 	let className = "";
 	export { className as class };
@@ -94,25 +100,20 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 	/** flies the sheet, set to `false` to remove */
 	export let transitionSheet: FlyParams | false = { duration };
 
-  /** if set to a value, the sheet will have a heading section with a close button */
- 	export let title = '';
+	let sheet: HTMLDivElement;
 
-	 let sheet: HTMLDivElement;
-	 const dispatch = createEventDispatcher();
-	
-	 const closeSheet = () => {
-		display = false;
-		dispatch('closed');
-	}
+	const dispatch = createEventDispatcher();
+
+	const close = () => (display = false);
 
 	const onKeyDown = (e: KeyboardEvent) => {
-		if (e.key === "Escape") {
-						closeSheet();
-		}
+		if (e.key === "Escape") close();
 	};
 
-	const focusElement: Action = (node: Node) => {
+	const lifecycle: Action = (node: Node) => {
+		dispatch("mount");
 		if (node instanceof HTMLElement) node.focus();
+		return { destroy: () => dispatch("destroy") };
 	};
 
 	if (transitionSheet && !transitionSheet.x && !transitionSheet.y) {
@@ -141,49 +142,26 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 {#if display}
 	<div
 		transition:blur={transition ? transition : { duration: 0 }}
-		use:focusElement
 		class="d-backdrop {className}"
 		class:d-backdrop-bottom={position === "b"}
 		class:d-backdrop-top={position === "t"}
 		class:d-backdrop-right={position === "r"}
 		{id}
-		tabindex="-1"
 	>
 		<div
-			role="dialog"
 			bind:this={sheet}
 			transition:fly={transitionSheet ? transitionSheet : { duration: 0 }}
+			use:lifecycle
+			role="dialog"
+			tabindex="-1"
 			style={position === "t" || position === "b"
 				? `max-height: ${maxSize}px;`
 				: `max-width: ${maxSize}px`}
 			class={classSheet}
 		>
-    {#if title}
-			<div class="header-container">
-				<div>
-					{title}
-				</div>
-				<button
-					class="header-button"
-					on:click={closeSheet}
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						height="30px"
-						width="30px"
-						viewBox="0 0 24 24"
-						fill="#000000"
-						><path d="M0 0h24v24H0V0z" fill="none" /><path
-							d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
-						/></svg
-					>
-				</button>
-			</div>
-    
-    {/if}
 			<slot>Content</slot>
 		</div>
-		<button title="Close" on:click={closeSheet}></button>
+		<button title="Close" on:click={close}></button>
 	</div>
 {/if}
 
@@ -208,33 +186,5 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 	}
 	.d-backdrop-right {
 		flex-direction: row-reverse;
-	}
-
-
-	.header-container {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding-top: 0.5rem;
-		padding-bottom: 0.5rem;
-		padding-right: 1rem;
-		font-size: 1.5rem;
-		font-weight: 800;
-	}
-
-	.header-button {
-		padding: 0.25rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		max-width: 38px;
-		max-height: 38px;
-		background-color: #e5e7eb;
-		border-radius: 9999px;
-		margin-left: 1rem;
-	}
-
-	.header-button:hover {
-		background-color: #d1d5db;
 	}
 </style>

--- a/src/lib/components/Sheet.svelte
+++ b/src/lib/components/Sheet.svelte
@@ -15,6 +15,7 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 - `position` - determines the position of sheet
 - `transitionSheet` - flies the sheet, set to `false` to remove
 - `transition` - blurs the entire component, set to `false` to remove
+- `title` - title of the sheet
 
 @slots
 
@@ -66,7 +67,8 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 		type BlurParams,
 		type FlyParams,
 	} from "svelte/transition";
-	import { prefersReducedMotion } from "$lib/util/accessibility";
+	import { createEventDispatcher, onMount } from 'svelte';
+  import { prefersReducedMotion } from "$lib/util/accessibility";
 	import { duration } from "$lib/util/transition";
 	import type { Action } from "svelte/action";
 
@@ -93,11 +95,19 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 	/** flies the sheet, set to `false` to remove */
 	export let transitionSheet: FlyParams | false = { duration };
 
+  /** if set to a value, the sheet will have a heading section with a close button */
+ 	export let title = '';
+
 	let sheet: HTMLDivElement;
+	const closeSheet = () => {
+		display = false;
+		dispatch('closed');
+	}
+
 
 	const onKeyDown = (e: KeyboardEvent) => {
 		if (e.key === "Escape") {
-			display = false;
+						closeSheet();
 		}
 	};
 
@@ -148,9 +158,32 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 				: `max-width: ${maxSize}px`}
 			class={classSheet}
 		>
+    {#if title}
+			<div class="header-container">
+				<div>
+					{title}
+				</div>
+				<button
+					class="header-button"
+					on:click={closeSheet}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						height="30px"
+						width="30px"
+						viewBox="0 0 24 24"
+						fill="#000000"
+						><path d="M0 0h24v24H0V0z" fill="none" /><path
+							d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+						/></svg
+					>
+				</button>
+			</div>
+    
+    {/if}
 			<slot>Content</slot>
 		</div>
-		<button title="Close" on:click={() => (display = false)}></button>
+		<button title="Close" on:click={closeSheet}></button>
 	</div>
 {/if}
 
@@ -175,5 +208,33 @@ Creates a sheet element based on the `position` provided. `maxSize` is set to wi
 	}
 	.d-backdrop-right {
 		flex-direction: row-reverse;
+	}
+
+
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding-top: 0.5rem;
+		padding-bottom: 0.5rem;
+		padding-right: 1rem;
+		font-size: 1.5rem;
+		font-weight: 800;
+	}
+
+	.header-button {
+		padding: 0.25rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		max-width: 38px;
+		max-height: 38px;
+		background-color: #e5e7eb;
+		border-radius: 9999px;
+		margin-left: 1rem;
+	}
+
+	.header-button:hover {
+		background-color: #d1d5db;
 	}
 </style>


### PR DESCRIPTION
- Added an optional `title` prop... it it has a value, the Sheet would display a bold title and a close button on top of the sheet.
- Added an on:closed event dispatcher to simplify tracking the status of the sheet and be able to execute clean-up functions if necessary, without needing to declare an extra display variable in the parent component and bind it to the display of the component.

Basically, it could optionally be used like a modal if needed.